### PR TITLE
refactor to create multiple service accounts per account

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Terrateam GCP OIDC setup
+
+This bootstraps a workload identity pool for github actions and creates service accounts that the pool can access, with optional restrictions to repositories for all, or per service account.
+
+The service accounts' permissions to modify GCP resources have to be granted elsewhere.

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,3 @@
-resource "google_service_account" "terrateam" {
-  account_id   = var.service_account_name
-  display_name = var.service_account_name
-  description  = var.service_account_description
-  project      = var.project_id
-}
-
 resource "google_iam_workload_identity_pool" "terrateam_pool" {
   project                   = var.project_id
   workload_identity_pool_id = var.workload_identity_pool_id
@@ -24,35 +17,29 @@ resource "google_iam_workload_identity_pool_provider" "terrateam_provider" {
     "attribute.repository_owner" = "assertion.repository_owner"
   }
   oidc {
-    #allowed_audiences = []
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
 }
 locals {
-  service_account_members = length(var.repositories) > 0 ? [
-    for repo in var.repositories : "principalSet://iam.googleapis.com/projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.repository/${var.github_org}/${repo}"
-    ] : [
-    "principalSet://iam.googleapis.com/projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.repository_owner/${var.github_org}"
-  ]
-}
-resource "google_service_account_iam_binding" "terrateam_workload_identity_user" {
-  #resource "google_service_account_iam_member" "terrateam_workload_identity_user" {
-  service_account_id = google_service_account.terrateam.id
-  role               = "roles/iam.workloadIdentityUser"
-  members = local.service_account_members
+  service_account_repositories = { for svc_acc in var.service_accounts :
+    svc_acc.name => length(svc_acc.repositories) > 0 ?
+    [for repo in svc_acc.repositories : "principalSet://iam.googleapis.com/projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.repository/${var.github_org}/${repo}"]
+    :
+    [for repo in var.default_repositories : "principalSet://iam.googleapis.com/projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.workload_identity_pool_id}/attribute.repository/${var.github_org}/${repo}"]
+  }
 }
 
-resource "google_project_iam_member" "terrateam_editor" {
-  for_each = { for role in var.service_account_roles : role.role => role }
-  project  = var.project_id
-  role     = each.value.role
-  member   = "serviceAccount:${google_service_account.terrateam.email}"
-  dynamic "condition" {
-    for_each = each.value.condition != null ? [each.value.condition] : []
-    content {
-      title       = condition.value.title
-      description = condition.value.description
-      expression  = condition.value.expression
-    }
-  }
+resource "google_service_account" "terrateam" {
+  for_each     = { for svc_acc in var.service_accounts : svc_acc.name => svc_acc }
+  account_id   = each.key
+  display_name = each.key
+  description  = each.value.description
+  project      = var.project_id
+}
+
+resource "google_service_account_iam_binding" "terrateam_workload_identity_user" {
+  for_each           = { for svc_acc in var.service_accounts : svc_acc.name => svc_acc }
+  service_account_id = google_service_account.terrateam[each.key].id
+  role               = "roles/iam.workloadIdentityUser"
+  members            = local.service_account_repositories[each.key]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,7 +2,10 @@ output "workload_identity_pool_provider_name" {
   description = "Terrateam provider workload identity pool"
   value       = google_iam_workload_identity_pool_provider.terrateam_provider.name
 }
-output "service_account_email" {
-  description = "Terrateam service account email"
-  value       = google_service_account.terrateam.email
+
+output "service_account_emails" {
+  description = "Terrateam service account identifiers"
+  value = { for svc_acc in var.service_accounts :
+    svc_acc.name => google_service_account.terrateam[svc_acc.name].email
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,17 +16,6 @@ variable "github_org" {
   }
 }
 
-variable "repositories" {
-  description = "Restrict to one or more GitHub repositories"
-  type        = list(string)
-  default     = []
-}
-
-variable "service_account_description" {
-  description = "Description for the service account"
-  type        = string
-}
-
 variable "workload_identity_pool_id" {
   description = "ID for the workload identity pool"
   type        = string
@@ -42,26 +31,17 @@ variable "workload_identity_provider_description" {
   type        = string
 }
 
-variable "service_account_name" {
-  description = "Name for the service account"
-  type        = string
+variable "default_repositories" {
+  description = "Restrict to one or more GitHub repositories, if not overridden per service account."
+  type        = list(string)
+  default     = []
 }
 
-#variable "service_account_role" {
-#  description = "Role for the service account"
-#  type        = string
-#  default     = "roles/editor"
-#}
-variable "service_account_roles" {
+variable "service_accounts" {
+  description = "Service accounts for impersonation by terrateam"
   type = list(object({
-    role = string
-    condition = optional(object({
-      title       = string
-      description = string
-      expression  = string
-    }))
+    name         = string
+    description  = optional(string, "Terrateam service account")
+    repositories = optional(list(string), [])
   }))
-  default = [
-    { role = "roles/editor" },
-  ]
 }


### PR DESCRIPTION
This refactors the service account creation to allow creating multiple service accounts, each one getting permission for use by the workload identity pool this module creates. Each account can be configured with specific repository limitations, or default to a module level list instead of every repo in the org.

I wanted to configure them with roles as well, using [terraform-google-iam-members](https://github.com/notablehealth/terraform-google-iam-members), but that module depends on static values for member names and this module creates them dynamically. Until that changes, this module sets up the workload authN and authZ is handled elsewhere.